### PR TITLE
fixes issue #45, creates payment options table

### DIFF
--- a/db/products/makePaymentOptionTable.js
+++ b/db/products/makePaymentOptionTable.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const sqlite3 = require("sqlite3").verbose();
-const db = new sqlite3.Database("api-sprint.sqlite");
 const { generateSqlTable } = require("../sqlRunTemplate");
 const payment_options = require("../../data/json/paymentOptions.json");
 

--- a/db/products/makePaymentOptionTable.js
+++ b/db/products/makePaymentOptionTable.js
@@ -2,7 +2,26 @@
 
 const sqlite3 = require("sqlite3").verbose();
 const db = new sqlite3.Database("api-sprint.sqlite");
+const { generateSqlTable } = require("../sqlRunTemplate");
+const payment_options = require("../../data/json/paymentOptions.json");
 
 module.exports = () => {
-  // function that creates payment options
+  generateSqlTable(
+    {
+      tableName: `Payment_Options`,
+      columns:
+      `payment_option_id INTEGER PRIMARY KEY,
+      type TEXT,
+      account_number TEXT,
+      customer_id INTEGER,
+      FOREIGN KEY(customer_id) REFERENCES Customers(customer_id)`,
+      dataToIterateOver: payment_options,
+      valuesToInsert: [
+        `payment_option_id`,
+        `type`,
+        `account_number`,
+        `customer_id`
+      ]
+    }
+  );
 }

--- a/db/sqlRunTemplate.js
+++ b/db/sqlRunTemplate.js
@@ -1,6 +1,6 @@
 'use strict';
 const sqlite3 = require("sqlite3").verbose();
-const db = new sqlite3.Database("api-sprint.sqlite");
+const db = new sqlite3.Database("db/api-sprint.sqlite");
 
 /*
 EXAMPLE FUNCTION CALL


### PR DESCRIPTION
# Description
This module should create a payment options table

## Number of Fixes
Fixes #45

## Steps to Test 
1. Run ``npm run db:generate``
1. Open ``db/api-sprint.sqlite`` in your database browser of choice

### Expected Result
1. You should see a ``Payment_Options`` table that corresponds to our ERD


