### PR TITLE
Escape Single Quotes in Faker String

### DIFF
--- a/db/sqlRunTemplate.js
+++ b/db/sqlRunTemplate.js
@@ -25,7 +25,7 @@ generateSqlTable(
 );
 */
 
-const escapeQuotes = stringValue => stringValue.replace("'", "''");
+const escapeSingleQuotes = stringValue => stringValue.replace("'", "''");
 
 // Drops the table if exists, then creates it and inserts the data from dataToIterateOver.
 // Values to Insert is what properties on each peice of data to iterate over that should be extracted
@@ -57,7 +57,7 @@ const generateSqlTable = ({ tableName, columns, dataToIterateOver, valuesToInser
 
         // Else it considers it a string
         else {
-          SqlValues += `'${escapeQuotes(object[value])}'`;
+          SqlValues += `'${escapeSingleQuotes(object[value])}'`;
         }
         
         // Add a comma to the string if it is not the final value

--- a/db/sqlRunTemplate.js
+++ b/db/sqlRunTemplate.js
@@ -25,7 +25,7 @@ generateSqlTable(
 );
 */
 
-const escapeString = stringValue => stringValue.replace("'", "''");
+const escapeQuotes = stringValue => stringValue.replace("'", "''");
 
 // Drops the table if exists, then creates it and inserts the data from dataToIterateOver.
 // Values to Insert is what properties on each peice of data to iterate over that should be extracted
@@ -57,7 +57,7 @@ const generateSqlTable = ({ tableName, columns, dataToIterateOver, valuesToInser
 
         // Else it considers it a string
         else {
-          SqlValues += `'${escapeString(object[value])}'`;
+          SqlValues += `'${escapeQuotes(object[value])}'`;
         }
         
         // Add a comma to the string if it is not the final value


### PR DESCRIPTION
# Description
This pull request adds a function that escape single quotes.  The function is used to escape single quotes in the sql code that is generated as a string and then ran.  

Also moved the adding of the comma between sql values to the end of the function instead of being used in each if statement.

## Related Ticket(s)
Fixes the bug in Issue #79 (generateSqlTable() should escape quotes)

## Problem to Solve
SQL throwing errors when there is a single quote in the supplied data.

## Proposed Changes
Escape all single quotes in string values from the JSON files we are using to create the database.

## Expected Behavior
The last_name in Customers "O'Conner" should not throw an error and should be changed to "O''Conner".

## Steps to Test Solution

1. Add ' between O and C in the last_name "OConner" in the customers JSON data.  Or add it anywhere in any of the string values.
1.  Run `npm run db:generate`
1.  There should be no errors.  