### PR TITLE
Fix escapeSingleQuote trying to escape undefined value

### DIFF
--- a/db/sqlRunTemplate.js
+++ b/db/sqlRunTemplate.js
@@ -25,7 +25,10 @@ generateSqlTable(
 );
 */
 
-const escapeSingleQuotes = stringValue => stringValue.replace("'", "''");
+const escapeSingleQuotes = value => 
+  typeof value === 'string' 
+    ? value.replace("'", "''") 
+    : value;
 
 // Drops the table if exists, then creates it and inserts the data from dataToIterateOver.
 // Values to Insert is what properties on each peice of data to iterate over that should be extracted


### PR DESCRIPTION
# Description
Change escapeSingleQuotes to check if value being passed into it is a string or not.  If it is, escape.  If not, don't escape string.

## Problem to Solve
Check if value trying to be escape is a string or not.  If it is a string, escape it, if not, don't escape it.  Before it was trying to run a .replace method on an undefined object.

## Proposed Changes
Check if value to be escaped is a string or not.

## Expected Behavior
No errors should be thrown when running `npm run db:generate`

## Steps to Test Solution

1. Run `npm run db:generate`
1. There should be no errors.  The output should be:
```
> bangazon-api-sprint1@1.0.0 db:generate C:\Users\Tim\workspace\group-projects\bangazon-api-sprint1
> node db/build-db.js
```
