### PR TITLE
Fixes #53: makeEmployeeTrainingTable finished

### DIFF
--- a/db/employees/makeEmployeeTrainingTable.js
+++ b/db/employees/makeEmployeeTrainingTable.js
@@ -1,5 +1,23 @@
 'use strict';
 
-module.exports = () => {
-  // function that creates employee_training join table
-}
+const { generateSqlTable } = require('../sqlRunTemplate');
+const employeeTrainingProgram = require('../../data/json/employeeTrainingPrograms');
+
+module.exports = () =>
+  generateSqlTable(
+    {
+      tableName: 'Employee_Training_Programs',
+      columns:
+	`employee_training_program_id INTEGER PRIMARY KEY,
+	training_program_id INT,
+	employee_id INT,
+	FOREIGN KEY (training_program_id) REFERENCES Training_Programs(training_program_id)
+	FOREIGN KEY (employee_id) REFERENCES Employees(employee_id)`,
+      dataToIterateOver: employeeTrainingProgram,
+      valuesToInsert: [
+	null,
+	'training_program_id',
+	'employee_id']
+    }
+  );
+


### PR DESCRIPTION
# Description
This provides the function to create the `Employee_Training_Programs` join table in the `db/employees/makeEmployeeTrainingTable` 

## Number of Fixes
1

## Related Ticket(s)
Fixes #53 

## Problem to Solve
`Employee_Training_Programs` join table did not exist

## Proposed Changes
`makeEmployeeTrainingTable` pulls in `generateSqlTable()` from `db/sqlRunTemplate` & data from `data/json/employeeTrainingProgram`, templates the data, and exports the resulting function

## Expected Behavior
`npm run db:generate` should create a `Employee_Training_Programs` table with fake data

## Steps to Test Solution

1. `npm run db:generate`
1. Open `db/api-spring.sqlite`
1. `SELECT * FROM  Employee_Training_Programs`
