### PR TITLE
Creates Employee_Computers join table, fixes issue #51

### DIFF
--- a/db/employees/makeEmployeeComputerTable.js
+++ b/db/employees/makeEmployeeComputerTable.js
@@ -1,8 +1,25 @@
 'use strict';
-
-const sqlite3 = require("sqlite3").verbose();
-const db = new sqlite3.Database("api-sprint.sqlite");
+const { generateSqlTable } = require("../sqlRunTemplate");
+const employeeComputers = require("../../data/json/employeeComputers.json");
 
 module.exports = () => {
-  // function that creates employee_customer join table
+  generateSqlTable(
+    {
+      tableName: `Employee_Computers`,
+      columns:
+      `computer_id INTEGER,
+      employee_id INTEGER,
+      start_date TEXT,
+      end_date TEXT,
+      FOREIGN KEY (computer_id) REFERENCES Computers(computer_id),
+      FOREIGN KEY (employee_id) REFERENCES Employees(employee_id)`,
+      dataToIterateOver: employeeComputers,
+      valuesToInsert: [
+        `computer_id`,
+        `employee_id`,
+        `start_date`,
+        `end_date`
+      ]
+    }
+  );
 }

--- a/db/sqlRunTemplate.js
+++ b/db/sqlRunTemplate.js
@@ -25,7 +25,10 @@ generateSqlTable(
 );
 */
 
-const escapeSingleQuotes = stringValue => stringValue.replace("'", "''");
+const escapeSingleQuotes = value => 
+  typeof value === 'string' 
+    ? value.replace("'", "''") 
+    : value;
 
 // Drops the table if exists, then creates it and inserts the data from dataToIterateOver.
 // Values to Insert is what properties on each peice of data to iterate over that should be extracted


### PR DESCRIPTION
# Description
This module should create the ``Employee_Computers join table``

## Related Ticket(s)
Issue #51

## Steps to Test Solution

1. ``npm run db:generate``
1. Open ``db/api-sprint.sqlite`` in your db browser of choice

## Expected Behavior
You should see a Employee_Computers join table with employee ids, computer ids, and the start adn end dates of the employee/computer relationship