### PR TITLE
Fixes #64 Sets up routes and end points for the Customers

### DIFF
--- a/controllers/products/customersCtrl.js
+++ b/controllers/products/customersCtrl.js
@@ -1,8 +1,42 @@
 "use strict";
 
 const appRoot = process.cwd();
+const { getAll, getOne, getFrugalCustomers } = require(appRoot + "/models/products/CustomersModel");
 
-const model = require(appRoot + "/models/CustomersModel");
+const getAllCustomers = (req, res, next) =>{
+  // This checks for the exact query url that was listed 
+  // in the wiki page for customers in our repo
+  if(req.query.active === "false"){
+    getFrugalCustomers()
+  .then((customers)=>{
+    res.status(200).json(customers);
+  })
+  .catch(error=>{
+    next(error);
+  });
+  }else{
+    getAll()
+    .then((customers)=>{
+      res.status(200).json(customers);
+    })
+    .catch(error=>{
+      next(error);
+    });
+  }
+};
+
+const getOneCustomer = (req, res, next) =>{
+  getOne(req.params.id)
+  .then((customer)=>{
+    res.status(200).json(customer);
+  })
+  .catch(error=>{
+    next(error);
+  });
+};
 
 
-module.exports = {  };
+module.exports = { 
+  getAllCustomers,
+  getOneCustomer
+ };

--- a/models/products/CustomersModel.js
+++ b/models/products/CustomersModel.js
@@ -3,4 +3,50 @@
 const sqlite3 = require('sqlite3');
 const db = new sqlite3.Database('./db/api-sprint.sqlite');
 
-module.exports = {};
+const getAll = () =>{
+  return new Promise((resolve, reject)=>{
+    db.all(
+      `SELECT Customers.* FROM Customers`,
+      (error, customers)=>{
+        if (error) return reject(error);
+        resolve(customers);
+      }
+    );
+  });
+};
+
+const getOne = id =>{
+  return new Promise((resolve, reject)=>{
+    db.all(
+      `SELECT Customers.* FROM Customers
+      WHERE Customers.customer_id = ${id}`,
+      (error, customer)=>{
+        if (error) return reject(error);
+        resolve(customer);
+      }
+    );
+  });
+};
+
+// This function looks for all customers that do not have any PAST orders
+const getFrugalCustomers = () =>{
+  return new Promise((resolve, reject)=>{
+    db.all(`
+    SELECT Customers.* 
+    FROM Customers
+    LEFT JOIN Orders
+    ON Customers.customer_id = Orders.customer_id
+    WHERE Orders.customer_id IS NULL
+    `, 
+    (error, customers)=>{
+      if (error) return reject(error);
+        resolve(customers);
+    });
+  });
+};
+
+module.exports = { 
+  getAll,
+  getOne,
+  getFrugalCustomers
+};

--- a/routes/products/customers.js
+++ b/routes/products/customers.js
@@ -5,9 +5,11 @@ const appRoot = process.cwd();
 const { Router } = require('express');
 const customersRouter = Router();
 
-const controller = require(appRoot + '/controllers/products/customersCtrl');
+const { getAllCustomers, getOneCustomer } = require(appRoot + '/controllers/products/customersCtrl');
 
 //TODO: routes & their corresponding controllers are enumerated here
-customersRouter.get('/', controller);
+customersRouter.get('/customers/:id', getOneCustomer);
+customersRouter.get('/customers', getAllCustomers);
+
 
 module.exports = customersRouter;


### PR DESCRIPTION
# Description
This sets up the routes and endpoints for the GET requests for Customers

## Related Ticket(s)
#64 
Fixes #11 

## Expected Behavior
go to http://127.0.0.1:8080/api/v1/customers and it should list all customers
go to http://127.0.0.1:8080/api/v1/customers/0 to see the first customer
 -- test other id numbers to see singular customers
go to http://127.0.0.1:8080/api/v1/customers?active=false to see just the customers that dont have any past orders


## Steps to Test Solution

1.  run `npm start` if you've already got the full database generated
1. comment out routes other than `/customers`
1. add `app.use('/api/v1/', routes);` after `routes` declaration in `app.js`
1. Go to the 3 urls listed above and see if they give the results

## Testing

[ ] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
[ ] I certify that all existing tests pass
// productsIndexRouter.use(require('./productOrders'));
// productsIndexRouter.use(require('./orders'));

## Documentation
[x] There is new documentation in this pull request that must be reviewed..
[ ] I added documentation for any new classes/methods

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.
