### PR TITLE
put now works on nonexistent computer ids

### DIFF
--- a/models/employees/ComputersModel.js
+++ b/models/employees/ComputersModel.js
@@ -65,12 +65,18 @@ const deleteComputer = id => {
 // update one computer by id
 const updateComputer = (id, {mac_address, purchase_date, decommission_date}) => {
   return new Promise((resolve, reject) => {
-    db.run(`UPDATE Computers
-            SET
-              mac_address="${mac_address}",
-              purchase_date="${purchase_date}",
-              decommission_date="${decommission_date}"
-            WHERE computer_id = ${id}`,
+    db.run(`REPLACE INTO Computers
+            (
+              computer_id,
+              mac_address,
+              purchase_date,
+              decommission_date
+            ) VALUES (
+              ${id},
+              "${mac_address}",
+              "${purchase_date}",
+              "${decommission_date}"
+            )`,
       err => {
         if (err) return reject(err);
         resolve(id);


### PR DESCRIPTION
# Description
When `PUT`ting, if you hit an id that a computer doesn't already own, it creates a new one

## Related Ticket(s)
#97 

## Steps to Test Solution
1. `npm checkout kb-computer-put`
1. `npm run db:generate`
1. comment out non-computer routes
1. postman: `PUT http://localhost:8080/api/v1/computers/25`
  ```js
  {"mac_address":"as:u:wish","purchase_date":"2016-10-08T13:17:00.534Z","decommission_date":"2017-06-22T09:18:52.019Z"}
  ```
1. `GET http://localhost:8080/api/v1/computers/25` should now give you the above data