### PR TITLE
/payment-options endpoints

### DIFF
--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -2,6 +2,7 @@
 
 const options = require("../../models/products/PaymentOptionsModel");
 
+// get single payment option by id
 module.exports.getSinglePaymentOption = (req, res, next) => {
   options.getSinglePaymentOption(req.params.id)
     .then(data => {
@@ -15,6 +16,7 @@ module.exports.getSinglePaymentOption = (req, res, next) => {
     .catch(err => next(err));
 };
 
+// get all payment options
 module.exports.getAllPaymentOptions = (req, res, next) => {
   options.getAllPaymentOptions()
     .then(data => {
@@ -28,6 +30,7 @@ module.exports.getAllPaymentOptions = (req, res, next) => {
     .catch(err => next(err));
 };
 
+// create new payment option
 module.exports.createNewPaymentOption = (req, res, next) => {
   let { type, account_number, customer_id } = req.body;
   if (type && account_number && customer_id) {
@@ -42,6 +45,7 @@ module.exports.createNewPaymentOption = (req, res, next) => {
   }
 };
 
+// update one payment option by id
 module.exports.updatePaymentOption = (req, res, next) => {
   let { type, account_number, customer_id } = req.body;
   if (type && account_number && customer_id) {
@@ -56,6 +60,7 @@ module.exports.updatePaymentOption = (req, res, next) => {
   }
 };
 
+// delete one payment option by id
 module.exports.deletePaymentOption = (req, res, next) => {
   if (req.params.id >= 0) {
     options.deletePaymentOption(req.params.id)

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -29,7 +29,17 @@ module.exports.getAllPaymentOptions = (req, res, next) => {
 };
 
 module.exports.createNewPaymentOption = (req, res, next) => {
-
+  let { type, account_number, customer_id } = req.body;
+  if (type && account_number && customer_id) {
+    options.createPaymentOption(req.body)
+      .then(data => {
+        res.status(200).json(data);
+      })
+      .catch(err => next(err));
+  } else {
+    let err = new Error("Please include a `type`, `account_number`, and `customer_id`.");
+    next(err);
+  }
 };
 
 module.exports.updatePaymentOption = (req, res, next) => {

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -3,11 +3,29 @@
 const options = require("../../models/products/PaymentOptionsModel");
 
 module.exports.getSinglePaymentOption = (req, res, next) => {
-
+  options.getSinglePaymentOption(req.params.id)
+    .then(data => {
+      if (data.length >= 1) {
+        res.status(200).json(data);
+      } else {
+        let err = new Error("Payment Option not found.");
+        next(err);
+      }
+    })
+    .catch(err => next(err));
 };
 
 module.exports.getAllPaymentOptions = (req, res, next) => {
-
+  options.getAllPaymentOptions()
+    .then(data => {
+      if (data.length >= 1) {
+        res.status(200).json(data);
+      } else {
+        let err = new Error("No Payment Options found.");
+        next(err);
+      }
+    })
+    .catch(err => next(err));
 };
 
 module.exports.createNewPaymentOption = (req, res, next) => {

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -1,9 +1,23 @@
 "use strict";
 
-const appRoot = process.cwd();
+const options = require("../../models/products/PaymentOptionsModel");
 
-const model = require(appRoot + "/models/PaymentOptionsModel");
+module.exports.getSinglePaymentOption = (req, res, next) => {
 
+};
 
+module.exports.getAllPaymentOptions = (req, res, next) => {
 
-module.exports = {  };
+};
+
+module.exports.createNewPaymentOption = (req, res, next) => {
+
+};
+
+module.exports.updatePaymentOption = (req, res, next) => {
+
+};
+
+module.exports.deletePaymentOption = (req, res, next) => {
+
+};

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -32,7 +32,7 @@ module.exports.getAllPaymentOptions = (req, res, next) => {
 
 // create new payment option
 module.exports.createNewPaymentOption = (req, res, next) => {
-  let { type, account_number, customer_id } = req.body;
+  const { type, account_number, customer_id } = req.body;
   if (type && account_number && customer_id) {
     options.createPaymentOption(req.body)
       .then(data => {

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -57,5 +57,11 @@ module.exports.updatePaymentOption = (req, res, next) => {
 };
 
 module.exports.deletePaymentOption = (req, res, next) => {
-
+  if (req.params.id >= 0) {
+    options.deletePaymentOption(req.params.id)
+      .then(id => {
+        res.status(200).json(id);
+      })
+      .catch(err => next(err));
+  }
 };

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -43,7 +43,17 @@ module.exports.createNewPaymentOption = (req, res, next) => {
 };
 
 module.exports.updatePaymentOption = (req, res, next) => {
-
+  let { type, account_number, customer_id } = req.body;
+  if (type && account_number && customer_id) {
+    options.updatePaymentOption(req.params.id, req.body)
+      .then(data => {
+        res.status(200).json(data);
+      })
+      .catch(err => next(err));
+  } else {
+    let err = new Error("Please include a `type`, `account_number`, and `customer_id`.");
+    next(err);
+  }
 };
 
 module.exports.deletePaymentOption = (req, res, next) => {

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -23,7 +23,20 @@ module.exports.getAllPaymentOptions = () => {
 };
 
 module.exports.createPaymentOption = ({type, account_number, customer_id}) => {
-  
+  return new Promise((resolve, reject) => {
+    db.run(`INSERT INTO Payment_Options (
+      type,
+      account_number,
+      customer_id
+    ) VALUES (
+      "${type}",
+      ${account_number},
+      ${customer_id}
+    )`, function(err) {
+      if (err) return reject(err);
+      resolve(this.lastID);
+    });
+  });
 };
 
 module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) => {

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -3,4 +3,21 @@
 const sqlite3 = require('sqlite3');
 const db = new sqlite3.Database('./db/api-sprint.sqlite');
 
-module.exports = {};
+module.exports.getSinglePaymentOption = id => {
+  
+};
+
+module.exports.getAllPaymentOptions = () => {
+  
+};
+
+module.exports.createPaymentOption = ({type, account_number, customer_id}) => {
+  
+};
+
+module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) => {
+};
+
+module.exports.deletePaymentOption = id => {
+
+};

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -4,11 +4,22 @@ const sqlite3 = require('sqlite3');
 const db = new sqlite3.Database('./db/api-sprint.sqlite');
 
 module.exports.getSinglePaymentOption = id => {
-  
+  return new Promise((resolve, reject) => {
+    db.all(`SELECT * FROM Payment_Options
+            WHERE payment_option_id = ${id}`, (err, data) => {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  });
 };
 
 module.exports.getAllPaymentOptions = () => {
-  
+  return new Promise((resolve, reject) => {
+    db.all(`SELECT * FROM Payment_Options`, (err, data) => {
+      if (err) return reject(err);
+      resolve(data);
+    });
+  });
 };
 
 module.exports.createPaymentOption = ({type, account_number, customer_id}) => {

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -59,5 +59,10 @@ module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) =
 };
 
 module.exports.deletePaymentOption = id => {
-
+  return new Promise((resolve, reject) => {
+    db.run(`DELETE FROM Payment_Options WHERE payment_option_id = ${id}`, err => {
+      if (err) return reject(err);
+      resolve(id);
+    });
+  });
 };

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -3,6 +3,7 @@
 const sqlite3 = require('sqlite3');
 const db = new sqlite3.Database('./db/api-sprint.sqlite');
 
+// get single payment option by id
 module.exports.getSinglePaymentOption = id => {
   return new Promise((resolve, reject) => {
     db.all(`SELECT * FROM Payment_Options
@@ -13,6 +14,7 @@ module.exports.getSinglePaymentOption = id => {
   });
 };
 
+// get all payment options
 module.exports.getAllPaymentOptions = () => {
   return new Promise((resolve, reject) => {
     db.all(`SELECT * FROM Payment_Options`, (err, data) => {
@@ -22,6 +24,7 @@ module.exports.getAllPaymentOptions = () => {
   });
 };
 
+// create new payment option
 module.exports.createPaymentOption = ({type, account_number, customer_id}) => {
   return new Promise((resolve, reject) => {
     db.run(`INSERT INTO Payment_Options (
@@ -39,6 +42,7 @@ module.exports.createPaymentOption = ({type, account_number, customer_id}) => {
   });
 };
 
+// update one payment option by id
 module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) => {
   return new Promise((resolve, reject) => {
     db.run(`REPLACE INTO Payment_Options (
@@ -58,11 +62,20 @@ module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) =
   });
 };
 
+// delete one payment option by id
 module.exports.deletePaymentOption = id => {
   return new Promise((resolve, reject) => {
-    db.run(`DELETE FROM Payment_Options WHERE payment_option_id = ${id}`, err => {
-      if (err) return reject(err);
-      resolve(id);
-    });
+    module.exports.getSinglePaymentOption(id)
+      .then(data => {
+        if (data.length >= 1) {
+          db.run(`DELETE FROM Payment_Options WHERE payment_option_id = ${id}`, err => {
+            if (err) return reject(err);
+            resolve(id);
+          });
+        } else {
+          let err = new Error("There is no Payment Option with that ID.");
+          reject(err);
+        }
+      })
   });
 };

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -40,6 +40,22 @@ module.exports.createPaymentOption = ({type, account_number, customer_id}) => {
 };
 
 module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) => {
+  return new Promise((resolve, reject) => {
+    db.run(`REPLACE INTO Payment_Options (
+      payment_option_id,
+      type,
+      account_number,
+      customer_id
+    ) VALUES (
+      ${id},
+      "${type}",
+      ${account_number},
+      ${customer_id}
+    )`, function(err) {
+      if (err) return reject(err);
+      resolve(this.lastID);
+    });
+  });
 };
 
 module.exports.deletePaymentOption = id => {

--- a/routes/products/index.js
+++ b/routes/products/index.js
@@ -8,6 +8,6 @@ productsIndexRouter.use(require('./products'));
 productsIndexRouter.use(require('./productOrders'));
 productsIndexRouter.use(require('./orders'));
 productsIndexRouter.use(require('./customers'));
-productsIndexRouter.use(require('./paymentOptions'));
+productsIndexRouter.use("/payment-options", require('./paymentOptions'));
 
 module.exports = productsIndexRouter;

--- a/routes/products/paymentOptions.js
+++ b/routes/products/paymentOptions.js
@@ -5,9 +5,17 @@ const appRoot = process.cwd();
 const { Router } = require('express');
 const paymentOptionsRouter = Router();
 
-const controller = require(appRoot + '/controllers/paymentOptionsCtrl');
+const controller = require("../../controllers/products/paymentOptionsCtrl");
 
-//TODO: routes & their corresponding controllers are enumerated here
-paymentOptionsRouter.get('/', controller);
+// GET /payment-options
+paymentOptionsRouter.get('/', controller.getAllPaymentOptions);
+// GET /payment-options/1
+paymentOptionsRouter.get("/:id", controller.getSinglePaymentOption);
+// POST /payment-options
+paymentOptionsRouter.post("/", controller.createNewPaymentOption);
+// PUT /payment-options/:id
+paymentOptionsRouter.put("/:id", controller.updatePaymentOption);
+// DELETE /payment-options/:id
+paymentOptionsRouter.delete("/:id", controller.deletePaymentOption);
 
 module.exports = paymentOptionsRouter;


### PR DESCRIPTION
# Description
Adds the following endpoints:
- `GET /payment-options`: gets all payment options
- `GET /payment-options/:id`: gets one payment option by id
- `POST /payment-options`: posts new payment option
- `PUT /payment-options/:id`: replaces/updates one payment option by id
- `DELETE /payment-options/:id`: removes one payment option by id

## Related Ticket(s)
fixes #108, fixes #3

## Steps to Test Solution
1. `npm run db:generate`
1. comment out non-payment option routes
1. http://localhost:8080/api/v1/payment-options should give you payment options with ids 0-9
1. http://localhost:8080/api/v1/payment-options/3 should give you an "invoice" payment option
1. `POST http://localhost:8080/api/v1/payment-options`:
    ```json
    {"type":"blood sacrifice","account_number":"1234","customer_id":3}
    ```
1. should return `25` and http://localhost:8080/api/v1/payment-options/25 should now give you the blood sacrifice payment option
1. `PUT http://localhost:8080/api/v1/payment-options/3`:
    ```json
    {"type":"blood sacrifice","account_number":"1234","customer_id":3}
    ```
1. should return `3` and http://localhost:8080/api/v1/payment-options/3 should now give you the blood sacrifice payment option
1. `PUT http://localhost:8080/api/v1/payment-options/31`:
    ```json
    {"type":"blood sacrifice","account_number":"1234","customer_id":3}
    ```
1. should return `31` and http://localhost:8080/api/v1/payment-options/31 should now give you the blood sacrifice payment option
1. `DELETE http://localhost:8080/api/v1/payment-options/31` should return `31` and http://localhost:8080/api/v1/payment-options/31 should now give you a "Payment option not found" error 
1. `DELETE http://localhost:8080/api/v1/payment-options/31` should now return a "Payment option not found" error