### PR TITLE
Tiny fix : handles errors with creating new orders

### DIFF
--- a/controllers/products/ordersCtrl.js
+++ b/controllers/products/ordersCtrl.js
@@ -27,7 +27,7 @@ module.exports.getSingleOrder = (req, res, next) => {
         order.Products = productData;
         res.status(200).json(order);
       } else {
-        res.status(404).send("Sorry! This order was not found.");
+        res.status(404).send(`Sorry! This order was not found.`);
       }  
     })
     .catch(error => {

--- a/models/products/OrdersModel.js
+++ b/models/products/OrdersModel.js
@@ -45,6 +45,9 @@ module.exports.getOrderProducts = id => {
 
 // Creates a new order
 module.exports.createOrder = ({ customer_id, payment_option_id }) => {
+  // if no payment option id was passed in, declare the payment option id as null.
+  if(!payment_option_id) payment_option_id = null; 
+  
   return new Promise((resolve, reject) => {
     db.run(`INSERT INTO Orders(
       customer_id, 

--- a/models/products/OrdersModel.js
+++ b/models/products/OrdersModel.js
@@ -47,7 +47,7 @@ module.exports.getOrderProducts = id => {
 module.exports.createOrder = ({ customer_id, payment_option_id }) => {
   // if no payment option id was passed in, declare the payment option id as null.
   if(!payment_option_id) payment_option_id = null; 
-  
+
   return new Promise((resolve, reject) => {
     db.run(`INSERT INTO Orders(
       customer_id, 
@@ -65,6 +65,10 @@ module.exports.createOrder = ({ customer_id, payment_option_id }) => {
 
 // Updates information on an order by id
 module.exports.updateOrder = (id, { customer_id, payment_option_id }) => {
+  
+  // if no payment option id was passed in, declare the payment option id as null.
+  if (!payment_option_id) payment_option_id = null; 
+
   return new Promise((resolve, reject) => {
     db.run(`REPLACE INTO Orders( 
       order_id,


### PR DESCRIPTION
# Description
This checks to see if users specify a payment_option_id when they create a new order. If they don't, it creates a payment_option_id with a value of null.

## Number of Fixes
Fixes #115

## Testing
1. Start your server.
1. `POST` the following JSON to `localhost:8080/api/v1/orders`:
``{"customer_id":1}``
1. Check what `id` that returns and go `GET` the order with that id (localhost:8080/api/v1/orders/id)
1. The order should have a `payment_option_id` and the value should be `null`.
