### PR TITLE
Fixes #107: this.changes on DELETE

### DIFF
--- a/controllers/employees/computersCtrl.js
+++ b/controllers/employees/computersCtrl.js
@@ -6,7 +6,7 @@ const computers = require("../../models/employees/ComputersModel");
 module.exports.getComputerById = (req, res, next) => {
   computers.getSingleComputer(req.params.id)
     .then(data =>
-      data ? res.status(200).json(data) : res.status(204).json()
+      data ? res.status(200).json(data) : res.status(204).send()
     )
     .catch(err => next(err));
 };
@@ -15,7 +15,7 @@ module.exports.getComputerById = (req, res, next) => {
 module.exports.getAllComputers = (req, res, next) => {
   computers.getAllComputers()
     .then(data =>
-      data.length >= 1 ? res.status(200).json(data) : res.status(204).json()
+      data.length >= 1 ? res.status(200).json(data) : res.status(204).send()
     )
     .catch(err => next(err));
 }
@@ -23,7 +23,9 @@ module.exports.getAllComputers = (req, res, next) => {
 // delete computer by id
 module.exports.deleteComputer = (req, res, next) => {
   computers.deleteComputer(req.params.id)
-    .then(id => res.status(200).json(id))
+    .then(changes =>
+      changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
+    )
     .catch(err => next(err));
 };
 

--- a/controllers/employees/trainingProgramsCtrl.js
+++ b/controllers/employees/trainingProgramsCtrl.js
@@ -15,7 +15,7 @@ module.exports.getTrainingProgramById = (req, res, next) => {
 module.exports.getAllTrainingPrograms = (req, res, next) => {
   programs.getAllTrainingPrograms()
     .then(data =>
-      data.length >= 1? res.status(200).json(data) : res.status(204).send()
+      data.length >= 1 ? res.status(200).json(data) : res.status(204).send()
     )
     .catch(err => next(err));
 };
@@ -43,7 +43,7 @@ module.exports.deleteTrainingProgram = (req, res, next) => {
   if (req.params.id >= 0) {
     programs.deleteTrainingProgram(req.params.id)
       .then(changes =>
-        changes >= 1 : res.status(200).json(changes) : res.status(204).send()
+        changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
       )
       .catch(err => next(err));
   }

--- a/controllers/employees/trainingProgramsCtrl.js
+++ b/controllers/employees/trainingProgramsCtrl.js
@@ -6,7 +6,7 @@ const programs = require("../../models/employees/TrainingProgramsModel");
 module.exports.getTrainingProgramById = (req, res, next) => {
   programs.getSingleTrainingProgram(req.params.id)
     .then(data =>
-      data ? res.status(200).json(data) : res.status(204).json()
+      data ? res.status(200).json(data) : res.status(204).send()
     )
     .catch(err => next(err));
 };
@@ -15,7 +15,7 @@ module.exports.getTrainingProgramById = (req, res, next) => {
 module.exports.getAllTrainingPrograms = (req, res, next) => {
   programs.getAllTrainingPrograms()
     .then(data =>
-      data.length >= 1? res.status(200).json(data) : res.status(204).json()
+      data.length >= 1? res.status(200).json(data) : res.status(204).send()
     )
     .catch(err => next(err));
 };
@@ -42,9 +42,9 @@ module.exports.updateTrainingProgram = (req, res, next) => {
 module.exports.deleteTrainingProgram = (req, res, next) => {
   if (req.params.id >= 0) {
     programs.deleteTrainingProgram(req.params.id)
-      .then(id => {
-        res.status(200).json(id);
-      })
+      .then(changes =>
+        changes >= 1 : res.status(200).json(changes) : res.status(204).send()
+      )
       .catch(err => next(err));
   }
 };

--- a/controllers/products/ordersCtrl.js
+++ b/controllers/products/ordersCtrl.js
@@ -67,9 +67,9 @@ module.exports.updateOrder = (req, res, next) => {
 // deletes an order by id
 module.exports.deleteOrder = (req, res, next) => {
   deleteOrder(req.params.id)
-    .then(data => {
-      res.status(200).json(data);
-    })
+    .then(changes =>
+      changes >= 1 ? res.status(200).json(data) : res.status(204).send()
+    )
     .catch(err => {
       next(err);
     })

--- a/controllers/products/ordersCtrl.js
+++ b/controllers/products/ordersCtrl.js
@@ -52,7 +52,7 @@ module.exports.updateOrder = (req, res, next) => {
 module.exports.deleteOrder = (req, res, next) => {
   deleteOrder(req.params.id)
     .then(changes =>
-      changes >= 1 ? res.status(200).json(data) : res.status(204).send()
+      changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
     )
     .catch(err => {
       next(err);

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -42,9 +42,9 @@ module.exports.updatePaymentOption = (req, res, next) => {
 module.exports.deletePaymentOption = (req, res, next) => {
   if (req.params.id >= 0) {
     options.deletePaymentOption(req.params.id)
-      .then(id => {
-        res.status(200).json(id);
-      })
+      .then(changes =>
+        changes >= 1 ? res.status(200).json(id) : res.status(204).send()
+      )
       .catch(err => next(err));
   }
 };

--- a/controllers/products/paymentOptionsCtrl.js
+++ b/controllers/products/paymentOptionsCtrl.js
@@ -43,7 +43,7 @@ module.exports.deletePaymentOption = (req, res, next) => {
   if (req.params.id >= 0) {
     options.deletePaymentOption(req.params.id)
       .then(changes =>
-        changes >= 1 ? res.status(200).json(id) : res.status(204).send()
+        changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
       )
       .catch(err => next(err));
   }

--- a/controllers/products/productTypesCtrl.js
+++ b/controllers/products/productTypesCtrl.js
@@ -39,5 +39,7 @@ module.exports.updateProductTypesTable = (req, res, next) => {
 
 module.exports.deleteProductType = (req, res, next) =>
   deleteProductType(req.params.id)
-  .then(changes => res.status(200).json(changes))
+  .then(changes =>
+    changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
+  )
   .catch(err => next(err));

--- a/controllers/products/productsCtrl.js
+++ b/controllers/products/productsCtrl.js
@@ -41,16 +41,8 @@ module.exports.updateProduct = (req, res, next) => {
 
 module.exports.deleteProduct = (req, res, next) => {
   deleteProduct(req.params.id)
-    .then(successfulDelete => {
-      if (successfulDelete) {
-        res.status(200).json(successfulDelete);
-      } else {
-        const err = new Error(
-          "The product could not be deleted. It may not exist."
-        );
-        err.status = 400;
-        next(err);
-      }
-    })
+    .then(changes =>
+      changes >= 1 ? res.status(200).json(changes) : res.status(204).send()
+    )
     .catch(err => next(err));
 };

--- a/models/employees/ComputersModel.js
+++ b/models/employees/ComputersModel.js
@@ -33,8 +33,7 @@ module.exports.deleteComputer = id =>
   new Promise((resolve, reject) =>
     db.run(`DELETE FROM Computers WHERE computer_id = ${id}`,
       function(err) {
-        if (err) return reject(err);
-        resolve(this.changes);
+        err ? reject(err) : resolve(this.changes);
       }
     )
   );

--- a/models/employees/ComputersModel.js
+++ b/models/employees/ComputersModel.js
@@ -29,20 +29,15 @@ module.exports.getAllComputers = () => {
 };
 
 // delete one computer by id
-module.exports.deleteComputer = id => {
-  return new Promise((resolve, reject) => {
-    getSingleComputer(id)
-      .then(computer => {
-        db.run(`DELETE FROM Computers
-                WHERE computer_id = ${id}`,
-        function(err) {
-          if (err) return reject(err);
-          resolve(this.changes);
-        });
-      })
-      .catch(err => reject(err));
-  });
-};
+module.exports.deleteComputer = id =>
+  new Promise((resolve, reject) =>
+    db.run(`DELETE FROM Computers WHERE computer_id = ${id}`,
+      function(err) {
+        if (err) return reject(err);
+        resolve(this.changes);
+      }
+    )
+  );
 
 // update one computer by id
 module.exports.updateComputer = (id, {mac_address, purchase_date, decommission_date}) => {

--- a/models/employees/ComputersModel.js
+++ b/models/employees/ComputersModel.js
@@ -37,7 +37,7 @@ module.exports.deleteComputer = id => {
                 WHERE computer_id = ${id}`,
         function(err) {
           if (err) return reject(err);
-          resolve(id);
+          resolve(this.changes);
         });
       })
       .catch(err => reject(err));

--- a/models/employees/TrainingProgramsModel.js
+++ b/models/employees/TrainingProgramsModel.js
@@ -51,19 +51,11 @@ module.exports.updateTrainingProgram = (id, { start_date, end_date, name, max_ca
 };
 
 // delete one training program by id
-module.exports.deleteTrainingProgram = id => {
-  return new Promise((resolve, reject) => {
-    module.exports.getSingleTrainingProgram(id)
-      .then(data => {
-        if (data.length >= 1) {
-          db.run(`DELETE FROM Training_Programs WHERE training_program_id = ${id}`, err => {
-            if (err) return reject(err);
-            resolve(id);
-          });
-        } else {
-          let err = new Error(`There is no Training Program with that ID.`);
-          reject(err);
-        }
-      })
-  });
-};
+module.exports.deleteTrainingProgram = id =>
+  new Promise((resolve, reject) =>
+    db.run(`DELETE FROM Training_Programs WHERE training_program_id = ${id}`,
+      function(err) {
+        err ? reject(err) : resolve(this.changes);
+      }
+    )
+  );

--- a/models/products/OrdersModel.js
+++ b/models/products/OrdersModel.js
@@ -34,25 +34,6 @@ module.exports.getOrderProducts = id =>
       });
   });
 
-<<<<<<< HEAD
-
-// Creates a new order
-module.exports.createOrder = ({ customer_id, payment_option_id = null }) =>
-  new Promise((resolve, reject) => {
-    db.run(`INSERT INTO Orders(
-      customer_id,
-      payment_option_id
-    ) VALUES (
-      ${customer_id},
-      ${payment_option_id}
-    )`,
-      function (err) {
-        err ? reject(err) : resolve(this.lastID);
-      })
-  });
-
-=======
->>>>>>> master
 // Updates information on an order by id
 module.exports.updateOrder = (id, { customer_id, payment_option_id = null }) =>
   new Promise((resolve, reject) => {

--- a/models/products/OrdersModel.js
+++ b/models/products/OrdersModel.js
@@ -76,7 +76,7 @@ module.exports.deleteOrder = id =>
       db.run(`PRAGMA foreign_keys = ON`);
       db.run(`DELETE FROM Orders WHERE order_id = ${id}`,
         function (err) {
-          return err ? reject(err) : resolve(id);
+          return err ? reject(err) : resolve(this.changes);
         }
       );
     });

--- a/models/products/OrdersModel.js
+++ b/models/products/OrdersModel.js
@@ -8,7 +8,7 @@ module.exports.getAllOrders = () =>
   new Promise((resolve, reject) => {
     db.all(`SELECT * FROM Orders`,
       (err, orders) => {
-        return err ? reject(err) : resolve(orders);
+        err ? reject(err) : resolve(orders);
       })
   });
 
@@ -17,7 +17,7 @@ module.exports.getSingleOrder = id =>
   new Promise((resolve, reject) => {
     db.get(`SELECT * FROM Orders WHERE order_id = ${id}`,
       (err, order) => {
-        return err ? reject(err) : resolve(order);
+        err ? reject(err) : resolve(order);
       });
   });
 
@@ -30,7 +30,7 @@ module.exports.getOrderProducts = id =>
           INNER JOIN Products ON Product_Orders.product_id = Products.product_id
           WHERE Orders.order_id = ${ id}`,
       (err, products) => {
-        return err ? reject(err) : resolve(products);
+        err ? reject(err) : resolve(products);
       });
   });
 
@@ -39,21 +39,21 @@ module.exports.getOrderProducts = id =>
 module.exports.createOrder = ({ customer_id, payment_option_id = null }) =>
   new Promise((resolve, reject) => {
     db.run(`INSERT INTO Orders(
-      customer_id, 
+      customer_id,
       payment_option_id
     ) VALUES (
-      ${customer_id}, 
+      ${customer_id},
       ${payment_option_id}
     )`,
       function (err) {
-        return err ? reject(err) : resolve(this.lastID);
+        err ? reject(err) : resolve(this.lastID);
       })
   });
 
 // Updates information on an order by id
 module.exports.updateOrder = (id, { customer_id, payment_option_id = null }) =>
   new Promise((resolve, reject) => {
-    db.run(`REPLACE INTO Orders( 
+    db.run(`REPLACE INTO Orders(
       order_id,
       customer_id,
       payment_option_id
@@ -63,7 +63,7 @@ module.exports.updateOrder = (id, { customer_id, payment_option_id = null }) =>
       ${payment_option_id}
     )`,
       function (err) {
-        return err ? reject(err) : resolve(this.lastID);
+        err ? reject(err) : resolve(this.lastID);
       });
   });
 
@@ -76,7 +76,7 @@ module.exports.deleteOrder = id =>
       db.run(`PRAGMA foreign_keys = ON`);
       db.run(`DELETE FROM Orders WHERE order_id = ${id}`,
         function (err) {
-          return err ? reject(err) : resolve(this.changes);
+          err ? reject(err) : resolve(this.changes);
         }
       );
     });

--- a/models/products/PaymentOptionsModel.js
+++ b/models/products/PaymentOptionsModel.js
@@ -45,19 +45,11 @@ module.exports.updatePaymentOption = (id, {type, account_number, customer_id}) =
 };
 
 // delete one payment option by id
-module.exports.deletePaymentOption = id => {
-  return new Promise((resolve, reject) => {
-    module.exports.getSinglePaymentOption(id)
-      .then(data => {
-        if (data.length >= 1) {
-          db.run(`DELETE FROM Payment_Options WHERE payment_option_id = ${id}`, err => {
-            if (err) return reject(err);
-            resolve(id);
-          });
-        } else {
-          let err = new Error("There is no Payment Option with that ID.");
-          reject(err);
-        }
-      })
-  });
-};
+module.exports.deletePaymentOption = id =>
+  new Promise((resolve, reject) =>
+    db.run(`DELETE FROM Payment_Options WHERE payment_option_id = ${id}`,
+      function(err) {
+        err ? reject(err) : resolve(this.changes);
+      }
+    )
+  );

--- a/models/products/ProductsModel.js
+++ b/models/products/ProductsModel.js
@@ -20,22 +20,22 @@ module.exports.getAllProducts = () => new Promise((resolve, reject) =>
 module.exports.updateProduct = (id, { price, title, description, product_type_id, creator_id }) =>
   new Promise((resolve, reject) => {
     db.run(`REPLACE INTO Products (
-      product_id, 
-      price, 
-      title, 
-      description, 
-      product_type_id, 
+      product_id,
+      price,
+      title,
+      description,
+      product_type_id,
       creator_id
     ) VALUES (
-      ${id == undefined ? null : id}, 
-      '${price}', 
-      '${title}', 
-      '${description}', 
-      '${product_type_id}', 
+      ${id == undefined ? null : id},
+      '${price}',
+      '${title}',
+      '${description}',
+      '${product_type_id}',
       '${creator_id}'
     )`,
       function (err) {
-        return err ? reject(err) : resolve(this.lastID);
+        err ? reject(err) : resolve(this.lastID);
       })
   });
 
@@ -44,6 +44,6 @@ module.exports.deleteProduct = id =>
     db.run(`DELETE FROM Products
       WHERE product_id = ${id}`,
       function (err) {
-        return err ? reject(err) : resolve(this.changes);
+        err ? reject(err) : resolve(this.changes);
       })
   });


### PR DESCRIPTION
# Description
We were a bit all over the place with what `DELETE` returns, and now all `DELETE` functions return `this.changes` and a `200` when something was there to `DELETE` and `204` when something was not there to `DELETE`, but the table does exist.

## Number of Fixes
1

## Related Ticket(s)
Fixes #107,
Completes #86 

## Problem to Solve
Inconsistent feedback was given to the user on a `DELETE` request, in particular with `ComputersModel`, `TrainingProgramsModel`, `OrdersModel`, `ProductsModel`, `ProductTypesModel` & `PaymentOptionsModel`
Accurate status codes were not being sent back from `DELETE` requests

## Proposed Changes
All `DELETE` requests return `this.changes`
If `this.changes` equals 1 (or more), sends back `200`
If `this.changes` equals 0, sends back `204`

## Expected Behavior
If successful `DELETE` then should return `1` and `200`. If nothing was present at that location, but the table exists, then `DELETE` returns `0` and `204`.

## Steps to Test Solution

1. `npm run db:generate`
1. `npm start`
1. `DELETE` `http://localhost:8080/api/v1/[table-name]/1` should return `200`
1. Then, again, `DELETE` `http://localhost:8080/api/v1/[table-name]/1` should return `204`
1. Tables to test are: `computers`, `training-programs`, `orders`, `products`, `product-types`, & `payment-options`

## Testing

- [x] I certify that all existing tests pass